### PR TITLE
Removed custom NBT methods in favor of INBTSerializable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,13 @@ buildscript {
 
     dependencies {
 
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
+        classpath "net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT"
         classpath "gradle.plugin.com.matthewprenger:CurseGradle:1.0.7"
     }
 }
 
 apply plugin: "maven"
-apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: "net.minecraftforge.gradle.forge"
 apply plugin: "com.matthewprenger.cursegradle"
 
 group = "net.darkhax.tesla"
@@ -34,9 +34,9 @@ version = getVersionFromJava(file("src/main/java/net/darkhax/tesla/lib/Constants
 //Defines the MC environment information.
 minecraft {
 
-    version = "1.9-12.16.0.1868-1.9"
+    version = "1.9-12.16.1.1887"
     runDir = "run"
-    mappings = 'snapshot_20160412'
+    mappings = "snapshot_20160501"
 }
 
 //Defines basic patterns for pulling various dependencies.

--- a/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
+++ b/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
@@ -2,81 +2,62 @@ package net.darkhax.tesla.api;
 
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.util.INBTSerializable;
 
 /**
  * An interface used by objects that can handle Tesla power.
  */
-public interface ITeslaHandler {
-    
+public interface ITeslaHandler extends INBTSerializable<NBTBase> {
+
     /**
      * Gets the amount of tesla power stored by the handler.
-     * 
+     *
      * @param side The side being checked.
      * @return The amount of tesla power stored by the handler.
      */
-    long getStoredPower (EnumFacing side);
-    
+    long getStoredPower(EnumFacing side);
+
     /**
      * Gets the maximum amount of tesla power that the handler can hold.
-     * 
+     *
      * @param side The side being checked.
      * @return The maximum amount of tesla power that can be held by the handler.
      */
-    long getCapacity (EnumFacing side);
-    
+    long getCapacity(EnumFacing side);
+
     /**
      * Takes power from the handler by removing it from an internal source.
-     * 
-     * @param power The amount of power to request from the handler.
-     * @param side The side being checked.
+     *
+     * @param power     The amount of power to request from the handler.
+     * @param side      The side being checked.
      * @param simulated Whether or not this is being called as part of a simulation.
      * @return The amount of power that was actually taken.
      */
-    long takePower (long power, EnumFacing side, boolean simulated);
-    
+    long takePower(long power, EnumFacing side, boolean simulated);
+
     /**
      * Provides the handler with a bit of power.
-     * 
-     * @param power The amount of power to provide the handler with.
-     * @param side The side being checked.
+     *
+     * @param power     The amount of power to provide the handler with.
+     * @param side      The side being checked.
      * @param simulated Whether or not this is being called as part of a simulation.
      * @return The amount of power that was accepted by the handler.
      */
-    long givePower (long power, EnumFacing side, boolean simulated);
-    
-    /**
-     * Serializes the handler to an NBT. Allows for critical information to be saved.
-     * 
-     * @param side The side of the handler that is being written. This is typically used for
-     *            block based implementations.
-     * @return A NBT that holds all critical information. Null can be returned if no data
-     *         storage is needed.
-     */
-    public NBTBase writeNBT (EnumFacing side);
-    
-    /**
-     * Desearializes the handler from an NBT. Allows for critical information to be read from
-     * saved data.
-     * 
-     * @param side The side of the handler that is being read. This is typically used for block
-     *            based implementations.
-     * @param nbt A NBT that holds the data. Should never be null.
-     */
-    public void readNBT (EnumFacing side, NBTBase nbt);
-    
+    long givePower(long power, EnumFacing side, boolean simulated);
+
     /**
      * Checks if a given side is a valid input face..
-     * 
+     *
      * @param side The side being checked.
      * @return Whether or not the side is a valid input side.
      */
-    boolean isInputSide (EnumFacing side);
-    
+    boolean isInputSide(EnumFacing side);
+
     /**
      * Checks if a given side is a valid output face.
-     * 
+     *
      * @param side The side being checked.
      * @return Whether or not the side is a valid output side.
      */
-    boolean isOutputSide (EnumFacing side);
+    boolean isOutputSide(EnumFacing side);
 }

--- a/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
+++ b/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
@@ -15,7 +15,7 @@ public interface ITeslaHandler extends INBTSerializable<NBTBase> {
      * @param side The side being checked.
      * @return The amount of tesla power stored by the handler.
      */
-    long getStoredPower(EnumFacing side);
+    long getStoredPower (EnumFacing side);
 
     /**
      * Gets the maximum amount of tesla power that the handler can hold.
@@ -23,27 +23,27 @@ public interface ITeslaHandler extends INBTSerializable<NBTBase> {
      * @param side The side being checked.
      * @return The maximum amount of tesla power that can be held by the handler.
      */
-    long getCapacity(EnumFacing side);
+    long getCapacity (EnumFacing side);
 
     /**
      * Takes power from the handler by removing it from an internal source.
      *
-     * @param power     The amount of power to request from the handler.
-     * @param side      The side being checked.
+     * @param power The amount of power to request from the handler.
+     * @param side The side being checked.
      * @param simulated Whether or not this is being called as part of a simulation.
      * @return The amount of power that was actually taken.
      */
-    long takePower(long power, EnumFacing side, boolean simulated);
+    long takePower (long power, EnumFacing side, boolean simulated);
 
     /**
      * Provides the handler with a bit of power.
      *
-     * @param power     The amount of power to provide the handler with.
-     * @param side      The side being checked.
+     * @param power The amount of power to provide the handler with.
+     * @param side The side being checked.
      * @param simulated Whether or not this is being called as part of a simulation.
      * @return The amount of power that was accepted by the handler.
      */
-    long givePower(long power, EnumFacing side, boolean simulated);
+    long givePower (long power, EnumFacing side, boolean simulated);
 
     /**
      * Checks if a given side is a valid input face..
@@ -51,7 +51,7 @@ public interface ITeslaHandler extends INBTSerializable<NBTBase> {
      * @param side The side being checked.
      * @return Whether or not the side is a valid input side.
      */
-    boolean isInputSide(EnumFacing side);
+    boolean isInputSide (EnumFacing side);
 
     /**
      * Checks if a given side is a valid output face.
@@ -59,5 +59,5 @@ public interface ITeslaHandler extends INBTSerializable<NBTBase> {
      * @param side The side being checked.
      * @return Whether or not the side is a valid output side.
      */
-    boolean isOutputSide(EnumFacing side);
+    boolean isOutputSide (EnumFacing side);
 }

--- a/src/main/java/net/darkhax/tesla/api/TeslaContainer.java
+++ b/src/main/java/net/darkhax/tesla/api/TeslaContainer.java
@@ -41,14 +41,12 @@ public class TeslaContainer implements ITeslaHandler {
     
     /**
      * Constructs a new TeslaContainer directly from save data.
-     * 
-     * @param side The side of the handler that is being read for. This is typically used for
-     *            block based implementations.
+     *
      * @return A NBT that holds all critical information.
      */
-    public TeslaContainer(EnumFacing side, NBTBase nbt) {
+    public TeslaContainer(NBTTagCompound nbt) {
         
-        this.readNBT(side, nbt);
+        this.deserializeNBT(nbt);
     }
     
     /**
@@ -189,7 +187,7 @@ public class TeslaContainer implements ITeslaHandler {
     }
     
     @Override
-    public NBTBase writeNBT (EnumFacing side) {
+    public NBTBase serializeNBT () {
         
         final NBTTagCompound dataTag = new NBTTagCompound();
         dataTag.setLong("TeslaPower", this.stored);
@@ -201,8 +199,8 @@ public class TeslaContainer implements ITeslaHandler {
     }
     
     @Override
-    public void readNBT (EnumFacing side, NBTBase nbt) {
-        
+    public void deserializeNBT (NBTBase nbt) {
+
         final NBTTagCompound dataTag = (NBTTagCompound) nbt;
         this.stored = dataTag.getLong("TeslaPower");
         

--- a/src/main/java/net/darkhax/tesla/capability/TeslaStorage.java
+++ b/src/main/java/net/darkhax/tesla/capability/TeslaStorage.java
@@ -7,20 +7,20 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.Capability.IStorage;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 
-public class TeslaStorage<T extends ITeslaHandler> implements IStorage<ITeslaHandler> {
+public class TeslaStorage<T extends ITeslaHandler> implements IStorage<T> {
     
     @CapabilityInject(ITeslaHandler.class)
     public static Capability<ITeslaHandler> TESLA_HANDLER_CAPABILITY = null;
     
     @Override
-    public NBTBase writeNBT (Capability<ITeslaHandler> capability, ITeslaHandler instance, EnumFacing side) {
+    public NBTBase writeNBT (Capability<T> capability, T instance, EnumFacing side) {
         
-        return instance.writeNBT(side);
+        return instance.serializeNBT();
     }
     
     @Override
-    public void readNBT (Capability<ITeslaHandler> capability, ITeslaHandler instance, EnumFacing side, NBTBase nbt) {
+    public void readNBT (Capability<T> capability, T instance, EnumFacing side, NBTBase nbt) {
         
-        instance.readNBT(side, nbt);
+        instance.deserializeNBT(nbt);
     }
 }

--- a/src/test/java/net/darkhax/teslatest/tileentity/TileEntityAnalyzer.java
+++ b/src/test/java/net/darkhax/teslatest/tileentity/TileEntityAnalyzer.java
@@ -36,7 +36,7 @@ public class TileEntityAnalyzer extends TileEntity implements ITickable {
         // doesn't care about side, so I am using null. You would use the correct EnumFacing
         // value if the ITeslaHandler implementation that you are using actually cares about
         // the side.
-        this.container = new TeslaContainer(null, compound.getTag("TeslaContainer"));
+        this.container = new TeslaContainer(compound.getCompoundTag("TeslaContainer"));
     }
     
     @Override
@@ -47,7 +47,7 @@ public class TileEntityAnalyzer extends TileEntity implements ITickable {
         // Writes the ITeslaHandler to the TileEntity NBT. Just like the read method, we are
         // using null for the face, because the default ITeslaHandler does not care about the
         // direction.
-        compound.setTag("TeslaContainer", this.container.writeNBT(null));
+        compound.setTag("TeslaContainer", this.container.serializeNBT());
     }
     
     @Override


### PR DESCRIPTION
See #10 and #5 

Decided not to add generics, because the capability handler only has a NBTBase argument.
Also updated forge and mappings, because why not. (I really hope I didn't mess up the formatting)
