### PR TITLE
Split capability into different roles.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,13 @@ buildscript {
 
     dependencies {
 
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
+        classpath "net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT"
         classpath "gradle.plugin.com.matthewprenger:CurseGradle:1.0.7"
     }
 }
 
 apply plugin: "maven"
-apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: "net.minecraftforge.gradle.forge"
 apply plugin: "com.matthewprenger.cursegradle"
 
 group = "net.darkhax.tesla"
@@ -34,9 +34,9 @@ version = getVersionFromJava(file("src/main/java/net/darkhax/tesla/lib/Constants
 //Defines the MC environment information.
 minecraft {
 
-    version = "1.9-12.16.0.1868-1.9"
+    version = "1.9-12.16.1.1887"
     runDir = "run"
-    mappings = 'snapshot_20160412'
+    mappings = "snapshot_20160501"
 }
 
 //Defines basic patterns for pulling various dependencies.

--- a/src/main/java/net/darkhax/tesla/Tesla.java
+++ b/src/main/java/net/darkhax/tesla/Tesla.java
@@ -1,8 +1,12 @@
 package net.darkhax.tesla;
 
-import net.darkhax.tesla.api.ITeslaHandler;
-import net.darkhax.tesla.api.TeslaContainer;
-import net.darkhax.tesla.capability.TeslaStorage;
+import net.darkhax.tesla.api.BaseTeslaContainer;
+import net.darkhax.tesla.api.ITeslaConsumer;
+import net.darkhax.tesla.api.ITeslaHolder;
+import net.darkhax.tesla.api.ITeslaProducer;
+import net.darkhax.tesla.capability.TeslaCapabilities.CapabilityTeslaConsumer;
+import net.darkhax.tesla.capability.TeslaCapabilities.CapabilityTeslaHolder;
+import net.darkhax.tesla.capability.TeslaCapabilities.CapabilityTeslaProducer;
 import net.darkhax.tesla.lib.Constants;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.fml.common.Mod;
@@ -18,6 +22,8 @@ public class Tesla {
     @EventHandler
     public void preInit (FMLPreInitializationEvent event) {
         
-        CapabilityManager.INSTANCE.register(ITeslaHandler.class, new TeslaStorage<ITeslaHandler>(), TeslaContainer.class);
+        CapabilityManager.INSTANCE.register(ITeslaConsumer.class, new CapabilityTeslaConsumer<ITeslaConsumer>(), BaseTeslaContainer.class);
+        CapabilityManager.INSTANCE.register(ITeslaProducer.class, new CapabilityTeslaProducer<ITeslaProducer>(), BaseTeslaContainer.class);
+        CapabilityManager.INSTANCE.register(ITeslaHolder.class, new CapabilityTeslaHolder<ITeslaHolder>(), BaseTeslaContainer.class);
     }
 }

--- a/src/main/java/net/darkhax/tesla/api/BaseTeslaContainer.java
+++ b/src/main/java/net/darkhax/tesla/api/BaseTeslaContainer.java
@@ -1,0 +1,222 @@
+package net.darkhax.tesla.api;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.INBTSerializable;
+
+/**
+ * A basic Tesla container that serves as a consumer, producer and holder. Custom
+ * implementations do not need to use all three. The INBTSerializable interface is also
+ * optional.
+ */
+public class BaseTeslaContainer implements ITeslaConsumer, ITeslaProducer, ITeslaHolder, INBTSerializable<NBTTagCompound> {
+    
+    /**
+     * The amount of stored Tesla power.
+     */
+    private long stored;
+    
+    /**
+     * The maximum amount of Tesla power that can be stored.
+     */
+    private long capacity;
+    
+    /**
+     * The maximum amount of Tesla power that can be accepted.
+     */
+    private long inputRate;
+    
+    /**
+     * The maximum amount of Tesla power that can be extracted
+     */
+    private long outputRate;
+    
+    /**
+     * Default constructor. Sets capacity to 5000 and transfer rate to 50. This constructor
+     * will not set the amount of stored power. These values are arbitrary and should not be
+     * taken as a base line for balancing.
+     */
+    public BaseTeslaContainer() {
+        
+        this(5000, 50, 50);
+    }
+    
+    /**
+     * Constructor for setting the basic values. Will not construct with any stored power.
+     * 
+     * @param capacity The maximum amount of Tesla power that the container should hold.
+     * @param input The maximum rate of power that can be accepted at a time.
+     * @param output The maximum rate of power that can be extracted at a time.
+     */
+    public BaseTeslaContainer(long capacity, long input, long output) {
+        
+        this(0, capacity, input, output);
+    }
+    
+    /**
+     * Constructor for setting all of the base values, including the stored power.
+     * 
+     * @param power The amount of stored power to initialize the container with.
+     * @param capacity The maximum amount of Tesla power that the container should hold.
+     * @param input The maximum rate of power that can be accepted at a time.
+     * @param output The maximum rate of power that can be extracted at a time.
+     */
+    public BaseTeslaContainer(long power, long capacity, long input, long output) {
+        
+        this.stored = power;
+        this.capacity = capacity;
+        this.inputRate = input;
+        this.outputRate = output;
+    }
+    
+    /**
+     * Constructor for creating an instance directly from a compound tag. This expects that the
+     * compound tag has some of the required data. @See {@link #readNBT(NBTTagCompound)} for
+     * precise info on what is expected. This constructor will only set the stored power if it
+     * has been written on the compound tag.
+     * 
+     * @param dataTag The NBTCompoundTag to read the important data from.
+     */
+    public BaseTeslaContainer(NBTTagCompound dataTag) {
+        
+        this.deserializeNBT(dataTag);
+    }
+    
+    @Override
+    public long getStoredPower () {
+        
+        return this.stored;
+    }
+    
+    @Override
+    public long givePower (long Tesla, boolean simulated) {
+        
+        final long acceptedTesla = Math.min(this.capacity - this.stored, Math.min(this.inputRate, Tesla));
+        
+        if (!simulated)
+            this.stored += acceptedTesla;
+            
+        return acceptedTesla;
+    }
+    
+    @Override
+    public long takePower (long Tesla, boolean simulated) {
+        
+        final long removedPower = Math.min(this.stored, Math.min(this.outputRate, Tesla));
+        
+        if (!simulated)
+            this.stored -= removedPower;
+            
+        return removedPower;
+    }
+    
+    @Override
+    public long getCapacity () {
+        
+        return this.capacity;
+    }
+    
+    @Override
+    public NBTTagCompound serializeNBT () {
+        
+        final NBTTagCompound dataTag = new NBTTagCompound();
+        dataTag.setLong("TeslaPower", this.stored);
+        dataTag.setLong("TeslaCapacity", this.capacity);
+        dataTag.setLong("TeslaInput", this.inputRate);
+        dataTag.setLong("TeslaOutput", this.outputRate);
+        
+        return dataTag;
+    }
+    
+    @Override
+    public void deserializeNBT (NBTTagCompound nbt) {
+        
+        this.stored = nbt.getLong("TeslaPower");
+        
+        if (nbt.hasKey("TeslaCapacity"))
+            this.capacity = nbt.getLong("TeslaCapacity");
+            
+        if (nbt.hasKey("TeslaInput"))
+            this.inputRate = nbt.getLong("TeslaInput");
+            
+        if (nbt.hasKey("TeslaOutput"))
+            this.outputRate = nbt.getLong("TeslaOutput");
+            
+        if (this.stored > this.capacity)
+            this.stored = this.capacity;
+    }
+    
+    /**
+     * Sets the capacity of the the container. If the existing stored power is more than the
+     * new capacity, the stored power will be decreased to match the new capacity.
+     * 
+     * @param capacity The new capacity for the container.
+     * @return The instance of the container being updated.
+     */
+    public BaseTeslaContainer setCapacity (long capacity) {
+        
+        this.capacity = capacity;
+        
+        if (this.stored > capacity)
+            this.stored = capacity;
+            
+        return this;
+    }
+    
+    /**
+     * Gets the maximum amount of Tesla power that can be accepted by the container.
+     * 
+     * @return The amount of Tesla power that can be accepted at any time.
+     */
+    public long getInputRate () {
+        
+        return this.inputRate;
+    }
+    
+    /**
+     * Sets the maximum amount of Tesla power that can be accepted by the container.
+     * 
+     * @param rate The amount of Tesla power to accept at a time.
+     * @return The instance of the container being updated.
+     */
+    public BaseTeslaContainer setInputRate (long rate) {
+        
+        this.inputRate = rate;
+        return this;
+    }
+    
+    /**
+     * Gets the maximum amount of Tesla power that can be pulled from the container.
+     * 
+     * @return The amount of Tesla power that can be extracted at any time.
+     */
+    public long getOutputRate () {
+        
+        return this.outputRate;
+    }
+    
+    /**
+     * Sets the maximum amount of Tesla power that can be pulled from the container.
+     * 
+     * @param rate The amount of Tesla power that can be extracted.
+     * @return The instance of the container being updated.
+     */
+    public BaseTeslaContainer setOutputRate (long rate) {
+        
+        this.outputRate = rate;
+        return this;
+    }
+    
+    /**
+     * Sets both the input and output rates of the container at the same time. Both rates will
+     * be the same.
+     * 
+     * @param rate The input/output rate for the Tesla container.
+     * @return The instance of the container being updated.
+     */
+    public BaseTeslaContainer setTransferRate (long rate) {
+        
+        this.setInputRate(rate);
+        this.setOutputRate(rate);
+        return this;
+    }
+}

--- a/src/main/java/net/darkhax/tesla/api/ITeslaConsumer.java
+++ b/src/main/java/net/darkhax/tesla/api/ITeslaConsumer.java
@@ -1,0 +1,14 @@
+package net.darkhax.tesla.api;
+
+public interface ITeslaConsumer {
+    
+    /**
+     * Offers power to the Tesla Consumer.
+     * 
+     * @param power The amount of power to offer.
+     * @param simulated Whether or not this is being called as part of a simulation.
+     *            Simulations are used to get information without affecting the Tesla Producer.
+     * @return The amount of power that the consumer accepts.
+     */
+    long givePower (long power, boolean simulated);
+}

--- a/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
+++ b/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
@@ -5,7 +5,11 @@ import net.minecraft.util.EnumFacing;
 
 /**
  * An interface used by objects that can handle Tesla power.
+ * 
+ * @deprecated The tesla capability is being split into three separate capabilities. Do not use
+ *             this capability! It will be removed in 1.0.3
  */
+@Deprecated
 public interface ITeslaHandler {
     
     /**

--- a/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
+++ b/src/main/java/net/darkhax/tesla/api/ITeslaHandler.java
@@ -18,6 +18,7 @@ public interface ITeslaHandler {
      * @param side The side being checked.
      * @return The amount of tesla power stored by the handler.
      */
+    @Deprecated
     long getStoredPower (EnumFacing side);
     
     /**
@@ -26,6 +27,7 @@ public interface ITeslaHandler {
      * @param side The side being checked.
      * @return The maximum amount of tesla power that can be held by the handler.
      */
+    @Deprecated
     long getCapacity (EnumFacing side);
     
     /**
@@ -36,6 +38,7 @@ public interface ITeslaHandler {
      * @param simulated Whether or not this is being called as part of a simulation.
      * @return The amount of power that was actually taken.
      */
+    @Deprecated
     long takePower (long power, EnumFacing side, boolean simulated);
     
     /**
@@ -46,6 +49,7 @@ public interface ITeslaHandler {
      * @param simulated Whether or not this is being called as part of a simulation.
      * @return The amount of power that was accepted by the handler.
      */
+    @Deprecated
     long givePower (long power, EnumFacing side, boolean simulated);
     
     /**
@@ -56,6 +60,7 @@ public interface ITeslaHandler {
      * @return A NBT that holds all critical information. Null can be returned if no data
      *         storage is needed.
      */
+    @Deprecated
     public NBTBase writeNBT (EnumFacing side);
     
     /**
@@ -66,6 +71,7 @@ public interface ITeslaHandler {
      *            based implementations.
      * @param nbt A NBT that holds the data. Should never be null.
      */
+    @Deprecated
     public void readNBT (EnumFacing side, NBTBase nbt);
     
     /**
@@ -74,6 +80,7 @@ public interface ITeslaHandler {
      * @param side The side being checked.
      * @return Whether or not the side is a valid input side.
      */
+    @Deprecated
     boolean isInputSide (EnumFacing side);
     
     /**
@@ -82,5 +89,6 @@ public interface ITeslaHandler {
      * @param side The side being checked.
      * @return Whether or not the side is a valid output side.
      */
+    @Deprecated
     boolean isOutputSide (EnumFacing side);
 }

--- a/src/main/java/net/darkhax/tesla/api/ITeslaHolder.java
+++ b/src/main/java/net/darkhax/tesla/api/ITeslaHolder.java
@@ -1,0 +1,18 @@
+package net.darkhax.tesla.api;
+
+public interface ITeslaHolder {
+    
+    /**
+     * Gets the amount of Tesla power stored being stored.
+     * 
+     * @return The amount of Tesla power being stored.
+     */
+    long getStoredPower ();
+    
+    /**
+     * Gets the maximum amount of Tesla power that can be held.
+     * 
+     * @return The maximum amount of Tesla power that can be held.
+     */
+    long getCapacity ();
+}

--- a/src/main/java/net/darkhax/tesla/api/ITeslaProducer.java
+++ b/src/main/java/net/darkhax/tesla/api/ITeslaProducer.java
@@ -1,0 +1,14 @@
+package net.darkhax.tesla.api;
+
+public interface ITeslaProducer {
+    
+    /**
+     * Requests an amount of power from the Tesla Producer.
+     * 
+     * @param power The amount of power to request.
+     * @param simulated Whether or not this is being called as part of a simulation.
+     *            Simulations are used to get information without affecting the Tesla Producer.
+     * @return The amount of power that the Tesla Producer will give.
+     */
+    long takePower (long power, boolean simulated);
+}

--- a/src/main/java/net/darkhax/tesla/api/InfiniteTeslaConsumer.java
+++ b/src/main/java/net/darkhax/tesla/api/InfiniteTeslaConsumer.java
@@ -3,26 +3,36 @@ package net.darkhax.tesla.api;
 import net.minecraft.util.EnumFacing;
 
 /**
- * An implementation of the TeslaContainer that will consume Tesla power indefinitely. This
- * implementation can not send power.
+ * Logic for a Tesla Consumer that will consume infinite amounts of power.
+ * 
+ * As of 1.0.2.x the TeslaContainer has been deprecated. It will be removed in 1.0.3.x
  */
-public class InfiniteTeslaConsumer extends TeslaContainer {
+public class InfiniteTeslaConsumer extends TeslaContainer implements ITeslaConsumer {
     
     @Override
+    @Deprecated
     public long givePower (long tesla, EnumFacing side, boolean simulated) {
         
         return tesla;
     }
     
     @Override
+    @Deprecated
     public long takePower (long tesla, EnumFacing side, boolean simulated) {
         
         return 0;
     }
     
     @Override
+    @Deprecated
     public boolean isOutputSide (EnumFacing side) {
         
         return false;
+    }
+    
+    @Override
+    public long givePower (long power, boolean simulated) {
+        
+        return power;
     }
 }

--- a/src/main/java/net/darkhax/tesla/api/InfiniteTeslaProducer.java
+++ b/src/main/java/net/darkhax/tesla/api/InfiniteTeslaProducer.java
@@ -3,26 +3,36 @@ package net.darkhax.tesla.api;
 import net.minecraft.util.EnumFacing;
 
 /**
- * An implementation of the TeslaContainer that will produce Tesla power indefinitely. This
- * implementation can not recieve power.
+ * Logic for a Tesla Producer that will produce an infinite amount of energy.
+ * 
+ * As of 1.0.2.x the TeslaContainer has been deprecated. It will be removed in 1.0.3.x
  */
-public class InfiniteTeslaProducer extends TeslaContainer {
+public class InfiniteTeslaProducer extends TeslaContainer implements ITeslaProducer {
     
     @Override
+    @Deprecated
     public long givePower (long tesla, EnumFacing side, boolean simulated) {
         
         return 0;
     }
     
     @Override
+    @Deprecated
     public long takePower (long tesla, EnumFacing side, boolean simulated) {
         
         return tesla;
     }
     
     @Override
+    @Deprecated
     public boolean isInputSide (EnumFacing side) {
         
         return false;
+    }
+    
+    @Override
+    public long takePower (long power, boolean simulated) {
+        
+        return power;
     }
 }

--- a/src/main/java/net/darkhax/tesla/api/TeslaContainer.java
+++ b/src/main/java/net/darkhax/tesla/api/TeslaContainer.java
@@ -6,7 +6,11 @@ import net.minecraft.util.EnumFacing;
 
 /**
  * A basic implementation of the ITeslaHandler. Can be used as a tank, similarly to FluidTank.
+ * 
+ * @deprecated The tesla capability is being split into three separate capabilities. Do not use
+ *             this capability! It will be removed in 1.0.3
  */
+@Deprecated
 public class TeslaContainer implements ITeslaHandler {
     
     /**

--- a/src/main/java/net/darkhax/tesla/capability/TeslaCapabilities.java
+++ b/src/main/java/net/darkhax/tesla/capability/TeslaCapabilities.java
@@ -1,0 +1,73 @@
+package net.darkhax.tesla.capability;
+
+import net.darkhax.tesla.api.ITeslaConsumer;
+import net.darkhax.tesla.api.ITeslaHolder;
+import net.darkhax.tesla.api.ITeslaProducer;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.Capability.IStorage;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+
+public class TeslaCapabilities {
+    
+    @CapabilityInject(ITeslaConsumer.class)
+    public static Capability<ITeslaConsumer> CAPABILITY_CONSUMER = null;
+    
+    @CapabilityInject(ITeslaProducer.class)
+    public static Capability<ITeslaProducer> CAPABILITY_PRODUCER = null;
+    
+    @CapabilityInject(ITeslaHolder.class)
+    public static Capability<ITeslaHolder> CAPABILITY_HOLDER = null;
+    
+    public static class CapabilityTeslaConsumer<T extends ITeslaConsumer> implements IStorage<ITeslaConsumer> {
+        
+        @Override
+        public NBTBase writeNBT (Capability<ITeslaConsumer> capability, ITeslaConsumer instance, EnumFacing side) {
+            
+            return null;
+        }
+        
+        @Override
+        public void readNBT (Capability<ITeslaConsumer> capability, ITeslaConsumer instance, EnumFacing side, NBTBase nbt) {
+        
+        }
+    }
+    
+    public static class CapabilityTeslaProducer<T extends ITeslaProducer> implements IStorage<ITeslaProducer> {
+        
+        @Override
+        public NBTBase writeNBT (Capability<ITeslaProducer> capability, ITeslaProducer instance, EnumFacing side) {
+            
+            return null;
+        }
+        
+        @Override
+        public void readNBT (Capability<ITeslaProducer> capability, ITeslaProducer instance, EnumFacing side, NBTBase nbt) {
+        
+        }
+    }
+    
+    public static class CapabilityTeslaHolder<T extends ITeslaHolder> implements IStorage<ITeslaHolder> {
+        
+        @Override
+        public NBTBase writeNBT (Capability<ITeslaHolder> capability, ITeslaHolder instance, EnumFacing side) {
+            
+            return null;
+        }
+        
+        @Override
+        public void readNBT (Capability<ITeslaHolder> capability, ITeslaHolder instance, EnumFacing side, NBTBase nbt) {
+        
+        }
+    }
+    
+    public static class BaseTeslaConsumer implements ITeslaConsumer {
+        
+        @Override
+        public long givePower (long power, boolean simulated) {
+            
+            return power;
+        }
+    }
+}

--- a/src/main/java/net/darkhax/tesla/capability/TeslaStorage.java
+++ b/src/main/java/net/darkhax/tesla/capability/TeslaStorage.java
@@ -7,6 +7,11 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.Capability.IStorage;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 
+@Deprecated
+/**
+ * @deprecated The tesla capability is being split into three separate capabilities. Do not use
+ *             this capability! It will be removed in 1.0.3
+ */
 public class TeslaStorage<T extends ITeslaHandler> implements IStorage<ITeslaHandler> {
     
     @CapabilityInject(ITeslaHandler.class)

--- a/src/main/java/net/darkhax/tesla/capability/TeslaStorage.java
+++ b/src/main/java/net/darkhax/tesla/capability/TeslaStorage.java
@@ -7,11 +7,11 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.Capability.IStorage;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 
-@Deprecated
 /**
  * @deprecated The tesla capability is being split into three separate capabilities. Do not use
  *             this capability! It will be removed in 1.0.3
  */
+@Deprecated
 public class TeslaStorage<T extends ITeslaHandler> implements IStorage<ITeslaHandler> {
     
     @CapabilityInject(ITeslaHandler.class)

--- a/src/main/java/net/darkhax/tesla/lib/Constants.java
+++ b/src/main/java/net/darkhax/tesla/lib/Constants.java
@@ -4,6 +4,6 @@ public class Constants {
     
     public static final String MOD_ID = "Tesla";
     public static final String MOD_NAME = "TESLA";
-    public static final String VERSION_NUMBER = "1.0.1.0";
+    public static final String VERSION_NUMBER = "1.0.2.0";
     public static final String MCVERSION = "[1.9,1.9.10]";
 }

--- a/src/test/java/net/darkhax/teslatest/block/BlockAnalyzer.java
+++ b/src/test/java/net/darkhax/teslatest/block/BlockAnalyzer.java
@@ -1,12 +1,20 @@
 package net.darkhax.teslatest.block;
 
+import net.darkhax.tesla.api.ITeslaHolder;
+import net.darkhax.tesla.capability.TeslaCapabilities;
 import net.darkhax.teslatest.tileentity.TileEntityAnalyzer;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 
 public class BlockAnalyzer extends BlockContainer {
@@ -16,6 +24,20 @@ public class BlockAnalyzer extends BlockContainer {
         super(Material.ROCK);
         this.setCreativeTab(CreativeTabs.REDSTONE);
         this.setUnlocalizedName("teslatest.analyzer");
+    }
+    
+    @Override
+    public boolean onBlockActivated (World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, ItemStack heldItem, EnumFacing side, float hitX, float hitY, float hitZ) {
+        
+        final TileEntity tile = worldIn.getTileEntity(pos);
+        
+        if (tile.hasCapability(TeslaCapabilities.CAPABILITY_HOLDER, side)) {
+            
+            final ITeslaHolder holder = tile.getCapability(TeslaCapabilities.CAPABILITY_HOLDER, side);
+            playerIn.addChatMessage(new TextComponentString("I have " + holder.getStoredPower() + " / " + holder.getCapacity() + " power."));
+        }
+        
+        return super.onBlockActivated(worldIn, pos, state, playerIn, hand, heldItem, side, hitX, hitY, hitZ);
     }
     
     @Override

--- a/src/test/java/net/darkhax/teslatest/block/BlockAnalyzer.java
+++ b/src/test/java/net/darkhax/teslatest/block/BlockAnalyzer.java
@@ -29,12 +29,15 @@ public class BlockAnalyzer extends BlockContainer {
     @Override
     public boolean onBlockActivated (World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, ItemStack heldItem, EnumFacing side, float hitX, float hitY, float hitZ) {
         
-        final TileEntity tile = worldIn.getTileEntity(pos);
-        
-        if (tile.hasCapability(TeslaCapabilities.CAPABILITY_HOLDER, side)) {
+        if (!worldIn.isRemote) {
             
-            final ITeslaHolder holder = tile.getCapability(TeslaCapabilities.CAPABILITY_HOLDER, side);
-            playerIn.addChatMessage(new TextComponentString("I have " + holder.getStoredPower() + " / " + holder.getCapacity() + " power."));
+            final TileEntity tile = worldIn.getTileEntity(pos);
+            
+            if (tile.hasCapability(TeslaCapabilities.CAPABILITY_HOLDER, side)) {
+                
+                final ITeslaHolder holder = tile.getCapability(TeslaCapabilities.CAPABILITY_HOLDER, side);
+                playerIn.addChatMessage(new TextComponentString("I have " + holder.getStoredPower() + " / " + holder.getCapacity() + " power."));
+            }
         }
         
         return super.onBlockActivated(worldIn, pos, state, playerIn, hand, heldItem, side, hitX, hitY, hitZ);

--- a/src/test/java/net/darkhax/teslatest/tileentity/TileEntityBlackhole.java
+++ b/src/test/java/net/darkhax/teslatest/tileentity/TileEntityBlackhole.java
@@ -1,23 +1,21 @@
 package net.darkhax.teslatest.tileentity;
 
 import net.darkhax.tesla.api.InfiniteTeslaConsumer;
-import net.darkhax.tesla.capability.TeslaStorage;
-import net.darkhax.tesla.lib.TeslaUtils;
+import net.darkhax.tesla.capability.TeslaCapabilities;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ITickable;
 import net.minecraftforge.common.capabilities.Capability;
 
 /**
  * A TileEntity that can consume unlimited amounts of tesla power.
  */
-public class TileEntityBlackhole extends TileEntity implements ITickable {
+public class TileEntityBlackhole extends TileEntity {
     
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getCapability (Capability<T> capability, EnumFacing facing) {
         
-        if (capability == TeslaStorage.TESLA_HANDLER_CAPABILITY)
+        if (capability == TeslaCapabilities.CAPABILITY_CONSUMER)
             return (T) new InfiniteTeslaConsumer();
             
         return super.getCapability(capability, facing);
@@ -26,15 +24,9 @@ public class TileEntityBlackhole extends TileEntity implements ITickable {
     @Override
     public boolean hasCapability (Capability<?> capability, EnumFacing facing) {
         
-        if (capability == TeslaStorage.TESLA_HANDLER_CAPABILITY)
+        if (capability == TeslaCapabilities.CAPABILITY_CONSUMER)
             return true;
             
         return super.hasCapability(capability, facing);
-    }
-    
-    @Override
-    public void update () {
-        
-        TeslaUtils.consumePowerEqually(this.worldObj, this.pos, 50, false);
     }
 }

--- a/src/test/java/net/darkhax/teslatest/tileentity/TileEntityCreativePower.java
+++ b/src/test/java/net/darkhax/teslatest/tileentity/TileEntityCreativePower.java
@@ -1,23 +1,21 @@
 package net.darkhax.teslatest.tileentity;
 
 import net.darkhax.tesla.api.InfiniteTeslaProducer;
-import net.darkhax.tesla.capability.TeslaStorage;
-import net.darkhax.tesla.lib.TeslaUtils;
+import net.darkhax.tesla.capability.TeslaCapabilities;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ITickable;
 import net.minecraftforge.common.capabilities.Capability;
 
 /**
  * A TileEntity that produces infinite amounts of tesla power.
  */
-public class TileEntityCreativePower extends TileEntity implements ITickable {
+public class TileEntityCreativePower extends TileEntity {
     
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getCapability (Capability<T> capability, EnumFacing facing) {
         
-        if (capability == TeslaStorage.TESLA_HANDLER_CAPABILITY)
+        if (capability == TeslaCapabilities.CAPABILITY_PRODUCER)
             return (T) new InfiniteTeslaProducer();
             
         return super.getCapability(capability, facing);
@@ -26,15 +24,9 @@ public class TileEntityCreativePower extends TileEntity implements ITickable {
     @Override
     public boolean hasCapability (Capability<?> capability, EnumFacing facing) {
         
-        if (capability == TeslaStorage.TESLA_HANDLER_CAPABILITY)
+        if (capability == TeslaCapabilities.CAPABILITY_PRODUCER)
             return true;
             
         return super.hasCapability(capability, facing);
-    }
-    
-    @Override
-    public void update () {
-        
-        TeslaUtils.distributePowerEqually(this.worldObj, this.pos, 50, false);
     }
 }


### PR DESCRIPTION
This PR is for the current solution to #10 and #5. 

Major changes
- Moved to 1.0.2.x
- Deprecated almost all of the old system.
- ITeslaHandler is now ITeslaConsumer, ITeslaProducer and ITeslaHolder
- TeslaContainer is now BaseTeslaContainer
- BaseTeslaContainer uses INBTSerializable rather than enforcing nbt serialization
