### PR TITLE
Use methods to determine I/O rate

### DIFF
--- a/src/main/java/net/darkhax/tesla/api/implementation/BaseTeslaContainer.java
+++ b/src/main/java/net/darkhax/tesla/api/implementation/BaseTeslaContainer.java
@@ -93,7 +93,7 @@ public class BaseTeslaContainer implements ITeslaConsumer, ITeslaProducer, ITesl
     @Override
     public long givePower (long Tesla, boolean simulated) {
         
-        final long acceptedTesla = Math.min(this.capacity - this.stored, Math.min(this.inputRate, Tesla));
+        final long acceptedTesla = Math.min(this.capacity - this.stored, Math.min(this.getInputRate(), Tesla));
         
         if (!simulated)
             this.stored += acceptedTesla;
@@ -104,7 +104,7 @@ public class BaseTeslaContainer implements ITeslaConsumer, ITeslaProducer, ITesl
     @Override
     public long takePower (long Tesla, boolean simulated) {
         
-        final long removedPower = Math.min(this.stored, Math.min(this.outputRate, Tesla));
+        final long removedPower = Math.min(this.stored, Math.min(this.getOutputRate(), Tesla));
         
         if (!simulated)
             this.stored -= removedPower;


### PR DESCRIPTION
Allows mod implementations to dynamically determine I/O rates

Example use case: Matter Overdrive machines have a base I/O rate that can be changed using upgrades. Having the `BaseTeslaContainer` use the `getInputRate` and `getOutputRate` methods instead of the fields themselves allows the upgrade multipliers to be easily applied in the overriden `getInputRate` and `getOutputRate` methods.
