### PR TITLE
Fix typo in Javadoc where @Darkhax deprecated the PENTATESLA field

### DIFF
--- a/src/main/java/net/darkhax/tesla/lib/TeslaUtils.java
+++ b/src/main/java/net/darkhax/tesla/lib/TeslaUtils.java
@@ -60,7 +60,7 @@ public class TeslaUtils {
     public static final long PENTATESLA = 1000000000000000L;
     
     /**
-     * The amount of Tesla in a PentaTesla. One Quadrillion.
+     * The amount of Tesla in a PetaTesla. One Quadrillion.
      */
     public static final long PETATESLA = 1000000000000000L;
     


### PR DESCRIPTION
Live long and prosper
